### PR TITLE
Lock cache file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(name='simple_cache',
       url='https://github.com/barisumog/simple_cache',
       py_modules=['simple_cache', 'test_simple_cache'],
       data_files=[('', ['README.rst'])],
+      install_requires=['filelock'],
       license="GPLv3"
      )

--- a/simple_cache.py
+++ b/simple_cache.py
@@ -40,6 +40,7 @@ def cons_lock_filename(orig_filename):
     """Create file name for the lock file."""
     return ".".join([orig_filename, "lock"])
 
+
 def write_cache(filename, cache):
     """Write the cache dictionary to disk."""
     lock = filelock.FileLock(cons_lock_filename(filename))

--- a/simple_cache.py
+++ b/simple_cache.py
@@ -36,9 +36,13 @@ except NameError:
 #
 
 
+def cons_lock_filename(orig_filename):
+    """Create file name for the lock file."""
+    return ".".join([orig_filename, "lock"])
+
 def write_cache(filename, cache):
     """Write the cache dictionary to disk."""
-    lock = filelock.FileLock(filename)
+    lock = filelock.FileLock(cons_lock_filename(filename))
     with lock.acquire(timeout=10):
         with open(filename, "w+b") as file:
             pickle.dump(cache, file)
@@ -46,7 +50,7 @@ def write_cache(filename, cache):
 
 def read_cache(filename):
     """Read a cache dictionary from disk."""
-    lock = filelock.FileLock(filename)
+    lock = filelock.FileLock(cons_lock_filename(filename))
     try:
         with lock.acquire(timeout=10):
             with open(filename, "r+b") as file:


### PR DESCRIPTION
Our use case is multiple processes utilizing single cache with short ttl. Unfortunately from time to time unpickling fails with value error.

```
Traceback (most recent call last):
[...]
  File "/usr/local/lib/python2.7/dist-packages/simple_cache.py", line 104, in wrapper
    value = load_key(filename, key)
  File "/usr/local/lib/python2.7/dist-packages/simple_cache.py", line 68, in load_key
    cache = read_cache(filename)
  File "/usr/local/lib/python2.7/dist-packages/simple_cache.py", line 48, in read_cache
    cache = pickle.load(file)
  File "/usr/lib/python2.7/pickle.py", line 1378, in load
    return Unpickler(file).load()
  File "/usr/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/usr/lib/python2.7/pickle.py", line 966, in load_string
    raise ValueError, "insecure string pickle"
ValueError: insecure string pickle
```

I think it is due to cache not being locked before writes/reads. So far I'm unable to reproduce the problem with this PR merged in.
